### PR TITLE
Addition of a different heuristic for the recommemdation of 3D signals.

### DIFF
--- a/generalTransform.cpp
+++ b/generalTransform.cpp
@@ -45,7 +45,9 @@ GeneralTransform &GeneralTransform::operator=(const GeneralTransform &tr) {
     this->isFloat = tr.isFloat;
     this->isForward = tr.isForward;
     this->isInPlace = tr.isInPlace;
-    this->isReal = tr.isReareturn *this;
+    this->isReal = tr.isReal;
+  }
+  return *this;
 }
 
 }  // namespace cuFFTAdvisor

--- a/generalTransform.cpp
+++ b/generalTransform.cpp
@@ -17,9 +17,7 @@ GeneralTransform::GeneralTransform(int device, int X, int Y, int Z, int N,
       isFloat(isFloat),
       isForward(isForward),
       isInPlace(isInPlace),
-      isReal(isReal) {
-        setRankInfo();
-      }
+      isReal(isReal) {}
 
 GeneralTransform::GeneralTransform(int X, int Y, int Z,
                                    const GeneralTransform &tr)
@@ -32,9 +30,7 @@ GeneralTransform::GeneralTransform(int X, int Y, int Z,
       isFloat(tr.isFloat),
       isForward(tr.isForward),
       isInPlace(tr.isInPlace),
-      isReal(tr.isReal) {
-        setRankInfo();
-      }
+      isReal(tr.isReal) {}
 
 GeneralTransform::GeneralTransform(const GeneralTransform &tr) { *this = tr; }
 
@@ -49,21 +45,7 @@ GeneralTransform &GeneralTransform::operator=(const GeneralTransform &tr) {
     this->isFloat = tr.isFloat;
     this->isForward = tr.isForward;
     this->isInPlace = tr.isInPlace;
-    this->isReal = tr.isReal;
-    setRankInfo();
-  }
-  return *this;
-}
-
-void GeneralTransform::setRankInfo() {
-  rank = RANK_3D;
-  if (1 == Z) {
-    if (1 == Y) {
-      rank = RANK_1D;
-    } else {
-      rank = RANK_2D;
-    }
-  }
+    this->isReal = tr.isReareturn *this;
 }
 
 }  // namespace cuFFTAdvisor

--- a/generalTransform.cpp
+++ b/generalTransform.cpp
@@ -17,7 +17,9 @@ GeneralTransform::GeneralTransform(int device, int X, int Y, int Z, int N,
       isFloat(isFloat),
       isForward(isForward),
       isInPlace(isInPlace),
-      isReal(isReal) {}
+      isReal(isReal) {
+        setRankInfo();
+      }
 
 GeneralTransform::GeneralTransform(int X, int Y, int Z,
                                    const GeneralTransform &tr)
@@ -30,7 +32,9 @@ GeneralTransform::GeneralTransform(int X, int Y, int Z,
       isFloat(tr.isFloat),
       isForward(tr.isForward),
       isInPlace(tr.isInPlace),
-      isReal(tr.isReal) {}
+      isReal(tr.isReal) {
+        setRankInfo();
+      }
 
 GeneralTransform::GeneralTransform(const GeneralTransform &tr) { *this = tr; }
 
@@ -46,8 +50,20 @@ GeneralTransform &GeneralTransform::operator=(const GeneralTransform &tr) {
     this->isForward = tr.isForward;
     this->isInPlace = tr.isInPlace;
     this->isReal = tr.isReal;
+    setRankInfo();
   }
   return *this;
+}
+
+void GeneralTransform::setRankInfo() {
+  rank = RANK_3D;
+  if (1 == Z) {
+    if (1 == Y) {
+      rank = RANK_1D;
+    } else {
+      rank = RANK_2D;
+    }
+  }
 }
 
 }  // namespace cuFFTAdvisor

--- a/generalTransform.h
+++ b/generalTransform.h
@@ -7,6 +7,9 @@ namespace cuFFTAdvisor {
 
 class GeneralTransform {
  public:
+
+  enum Rank { RANK_1D = 1, RANK_2D = 2, RANK_3D = 3 };
+
   GeneralTransform(int device, int X, int Y, int Z, int N,
                    Tristate::Tristate isBatched, Tristate::Tristate isFloat,
                    Tristate::Tristate isForward, Tristate::Tristate isInPlace,
@@ -30,6 +33,12 @@ class GeneralTransform {
   Tristate::Tristate isForward;  // otherwise inverse
   Tristate::Tristate isInPlace;  // otherwise out-of-place
   Tristate::Tristate isReal;     // otherwise C2C
+  Rank rank;
+
+  /**
+   * Sets fields that describe rank (dimensionality)
+   */
+  void setRankInfo();
 };
 
 }  // namespace cuFFTAdvisor

--- a/generalTransform.h
+++ b/generalTransform.h
@@ -8,8 +8,6 @@ namespace cuFFTAdvisor {
 class GeneralTransform {
  public:
 
-  enum Rank { RANK_1D = 1, RANK_2D = 2, RANK_3D = 3 };
-
   GeneralTransform(int device, int X, int Y, int Z, int N,
                    Tristate::Tristate isBatched, Tristate::Tristate isFloat,
                    Tristate::Tristate isForward, Tristate::Tristate isInPlace,
@@ -34,10 +32,6 @@ class GeneralTransform {
   Tristate::Tristate isInPlace;  // otherwise out-of-place
   Tristate::Tristate isReal;     // otherwise C2C
 
-  /**
-   * Sets fields that describe rank (dimensionality)
-   */
-  void setRankInfo();
 };
 
 }  // namespace cuFFTAdvisor

--- a/generalTransform.h
+++ b/generalTransform.h
@@ -33,7 +33,6 @@ class GeneralTransform {
   Tristate::Tristate isForward;  // otherwise inverse
   Tristate::Tristate isInPlace;  // otherwise out-of-place
   Tristate::Tristate isReal;     // otherwise C2C
-  Rank rank;
 
   /**
    * Sets fields that describe rank (dimensionality)

--- a/sizeOptimizer.cpp
+++ b/sizeOptimizer.cpp
@@ -168,7 +168,6 @@ std::vector<GeneralTransform> *SizeOptimizer::optimizeXYZ(GeneralTransform &tr,
                                                           bool squareOnly,
                                                           bool crop) {
 
-  bool rank = (tr.Z != 1 && tr.Y != 1 && tr.X != 1); //rank define if it is a 3D signal or not
   std::vector<Polynom> *polysX = generatePolys(tr.X, tr.isFloat, crop);
   std::vector<Polynom> *polysY;
   std::vector<Polynom> *polysZ;
@@ -176,7 +175,7 @@ std::vector<GeneralTransform> *SizeOptimizer::optimizeXYZ(GeneralTransform &tr,
   std::set<Polynom, valueComparator> *recPolysY;
   std::set<Polynom, valueComparator> *recPolysZ;
 
-  if(!rank){
+  if(tr.rank != 3){
     recPolysX = filterOptimal(polysX, crop);
   }else{
     polysX = cutN(polysX, nBest);
@@ -188,7 +187,7 @@ std::vector<GeneralTransform> *SizeOptimizer::optimizeXYZ(GeneralTransform &tr,
     recPolysY = recPolysX;
   } else {
     polysY = generatePolys(tr.Y, tr.isFloat, crop);
-    if(!rank){
+    if(tr.rank != 3){
       recPolysY = filterOptimal(polysY, crop);
     }else{
       polysY = cutN(polysY, nBest);
@@ -204,7 +203,7 @@ std::vector<GeneralTransform> *SizeOptimizer::optimizeXYZ(GeneralTransform &tr,
     recPolysZ = recPolysY;
   } else {
     polysZ = generatePolys(tr.Z, tr.isFloat, crop);
-    if(!rank){
+    if(tr.rank != 3){
       recPolysZ = filterOptimal(polysZ, crop);
     }else{
       polysZ = cutN(polysZ, nBest);
@@ -216,7 +215,7 @@ std::vector<GeneralTransform> *SizeOptimizer::optimizeXYZ(GeneralTransform &tr,
   size_t maxSize = getMaxSize(tr, maxPercIncrease, squareOnly, crop);
 
   std::vector<GeneralTransform> *result = new std::vector<GeneralTransform>;
-  if(!rank){
+  if(tr.rank != 3){
     size_t found = 0;
     for (auto& x : *recPolysX) {
       for (auto& y : *recPolysY) {
@@ -315,18 +314,18 @@ std::vector<GeneralTransform> *SizeOptimizer::optimizeXYZ(GeneralTransform &tr,
 
   if ((polysZ != polysY) && (polysZ != polysX)) {
     delete polysZ;
-    if (!rank){
+    if (tr.rank != 3){
       delete recPolysZ;
     }
   }
   if (polysY != polysX) {
     delete polysY;
-    if (!rank){
+    if (tr.rank != 3){
       delete recPolysY;
     }
   }
   delete polysX;
-  if (!rank){
+  if (tr.rank != 3){
     delete recPolysX;
   }
   return result;

--- a/sizeOptimizer.cpp
+++ b/sizeOptimizer.cpp
@@ -221,20 +221,14 @@ std::vector<GeneralTransform> *SizeOptimizer::optimizeXYZ(GeneralTransform &tr,
 
   if ((polysZ != polysY) && (polysZ != polysX)) {
     delete polysZ;
-    if (tr.rank != 3){
-      delete recPolysZ;
-    }
+    delete recPolysZ;
   }
   if (polysY != polysX) {
     delete polysY;
-    if (tr.rank != 3){
-      delete recPolysY;
-    }
+    delete recPolysY;
   }
   delete polysX;
-  if (tr.rank != 3){
-    delete recPolysX;
-  }
+  delete recPolysX;
   return result;
 }
 

--- a/sizeOptimizer.h
+++ b/sizeOptimizer.h
@@ -5,7 +5,6 @@
 #include <cmath>
 #include <set>
 #include <vector>
-#include <map>
 #include "benchmarker.h"
 #include "generalTransform.h"
 #include "transformGenerator.h"
@@ -23,16 +22,6 @@ class SizeOptimizer {
     size_t exponent3;
     size_t exponent5;
     size_t exponent7;
-
-    bool operator < (const Polynom& cmp) const
-    {
-        return (value < cmp.value);
-    }
-
-    bool operator > (const Polynom& cmp) const
-    {
-        return (value > cmp.value);
-    }
   };
 
   struct valueComparator {

--- a/sizeOptimizer.h
+++ b/sizeOptimizer.h
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <set>
 #include <vector>
+#include <map>
 #include "benchmarker.h"
 #include "generalTransform.h"
 #include "transformGenerator.h"
@@ -22,6 +23,16 @@ class SizeOptimizer {
     size_t exponent3;
     size_t exponent5;
     size_t exponent7;
+
+    bool operator < (const Polynom& cmp) const
+    {
+        return (value < cmp.value);
+    }
+
+    bool operator > (const Polynom& cmp) const
+    {
+        return (value > cmp.value);
+    }
   };
 
   struct valueComparator {
@@ -56,6 +67,7 @@ class SizeOptimizer {
 
   int getInvocations(Polynom &poly, bool isFloat);
   int getInvocationsV8(Polynom &poly, bool isFloat);
+  std::vector<Polynom> *cutN(std::vector<Polynom>* polys , size_t nBest);
   std::set<Polynom, valueComparator> *filterOptimal(
       std::vector<Polynom> *input, bool crop);
   std::vector<Polynom> *generatePolys(size_t num, bool isFloat, bool crop);


### PR DESCRIPTION
After running some tests, we conclude that, if the original heuristic is still relevant for 2D signals (in addition of 1D's), it is not so optimize for 3D signals.

With additional tests, we find out that, instead of searching for the less kernel invocations possible, it is more efficient for 3D signals to select polynoms the closest to the input.


This version complete the function "optimizeXYZ" in the file "sizeOptimizer", where the two case are evaluate (the original one for 1-2D signals and the new one for 3D's).
It also add a new function name "cutN" with limit the number of used polynoms to speed up the execution.


The new heuristic is slightly slower than the old one, but show better results.